### PR TITLE
Add methods to obtain the current config file from the robot

### DIFF
--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
@@ -817,4 +817,9 @@ public class FtcRobotControllerActivity extends Activity
       wifiMuteStateMachine.consumeEvent(WifiMuteEvent.USER_ACTIVITY);
     }
   }
+    
+    public RobotConfigFileManager getConfigFileManager() {
+    	return cfgFileMgr;
+    }
+    
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RC.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RC.java
@@ -9,7 +9,7 @@ import org.firstinspires.ftc.robotcontroller.internal.FtcRobotControllerActivity
 
 import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
 
-
+import com.qualcomm.ftccommon.configuration.RobotConfigFile;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.hardware.HardwareMap;
@@ -19,6 +19,8 @@ import java.util.HashMap;
 /**
  * Created by tycho on 2/18/2017. This was copied from Team FIXIT. All hail team FIXIT.
  * This is simply a set of utils to reference the main robot controller activity for convenience
+ * 
+ * Updated by Arjun to obtain current robot configuration (xml)
  */
 
 public class RC {
@@ -47,7 +49,12 @@ public class RC {
     public static Context c() {
         return AppUtil.getInstance().getActivity();
     }//context
+    
     public static FtcRobotControllerActivity a() {
         return ((FtcRobotControllerActivity) AppUtil.getInstance().getActivity());
-    }
+    }//activity
+    
+    public static RobotConfigFile config() {
+        return a().getConfigFileManager().getActiveConfig();
+    }//config
 }


### PR DESCRIPTION
Using this commit:

```java
String configName = RC.config().getName();
```

You can actually do several interesting things with the `RobotConfigFile` and `RobotConfigFileManager` objects (that's why I left them accessible). the `RobotConfigFile` allows you to obtain an XML parser of the actual current configuration, as well as determine it's file path, so you can modify it and reload the config during robot operation (doing that during an OpMode would probably mess stuff up though). The `RobotConfigFileManager` is more of an implementation detail of the RC phone (hence why I left it accessible only from the activity) but can let you get finer control over how configurations are parsed and selected.